### PR TITLE
Add ModalBottomSheetProperties to ModalBottomSheetLayout

### DIFF
--- a/material3-navigation/src/main/java/com/stefanoq21/material3/navigation/ModalBottomSheetLayout.kt
+++ b/material3-navigation/src/main/java/com/stefanoq21/material3/navigation/ModalBottomSheetLayout.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetDefaults
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -46,6 +48,7 @@ fun ModalBottomSheetLayout(
     scrimColor: Color = BottomSheetDefaults.ScrimColor,
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
+    properties: ModalBottomSheetProperties = ModalBottomSheetDefaults.properties,
     content: @Composable () -> Unit,
 ) {
 
@@ -76,6 +79,7 @@ fun ModalBottomSheetLayout(
             scrimColor = scrimColor,
             dragHandle = dragHandle,
             contentWindowInsets = contentWindowInsets,
+            properties = properties,
         )
     }
 }


### PR DESCRIPTION
A recent bug fix for `androidx.compose.material3:material3` addresses an issue in which the system status bars are incorrectly switched to "light mode" any time a `ModalBottomSheet` is shown, even if the app uses a dark theme.

See the issue tracker here:
[#362539765 ModalBottomSheet making status icons invisible in dark status bar ](https://issuetracker.google.com/issues/362539765)

The fix addresses the issue by adding two properties to `ModalBottomSheetProperties`:
* `isAppearanceLightStatusBars`
* `isAppearanceLightNavigationBars`

The issue tracker states that the bug fix is addressed in version `1.4.0-alpha03`+.

Since previously there are no appearance related flags in `ModalBottomSheetParameters`, it made sense to not include the properties in the `ModalBottomSheetLayout`. But that's no longer the case...

I'm not sure how you're handling `shouldDismissOnBackPress` which is the other relevant parameter passed to the sheet properties.

If you wanted to allow clients to only pass the `isAppearanceLight*` parameters and not `shouldDismissOnBackPress`, you'd have to bump the `material3` dependency to an alpha version.

Otherwise, this would allow clients to pass the entire `ModalBottomSheetParameters` to the layout but maybe it should come with a caveat regarding `shouldDismissOnBackPress` depending on how that's handled internally (I didn't dig into the code, but let me know what you think).

With option 2 (as implemented in this PR) you can continue to use a stable version of `material3` in the library code and clients can optionally pass the bottom sheet parameters to fix the bug described above.

Thanks for your work on this library. This is definitely helpful for me to have support for the `material3` bottom sheet in navigation!

