### PR TITLE
Allow passing a Modifier to the ModalBottomSheet

### DIFF
--- a/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/MainActivity.kt
+++ b/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/MainActivity.kt
@@ -55,6 +55,9 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSize()
                             .padding(innerPadding)
                             .padding(12.dp),
+                        /*sheetModifier = Modifier.windowInsetsPadding(
+                            WindowInsets.systemBars.only(WindowInsetsSides.Top)
+                        ),*/
                         bottomSheetNavigator = bottomSheetNavigator,
                         /*properties = ModalBottomSheetProperties(
                             isAppearanceLightStatusBars = !isSystemInDarkTheme(),

--- a/material3-navigation/src/main/java/com/stefanoq21/material3/navigation/ModalBottomSheetLayout.kt
+++ b/material3-navigation/src/main/java/com/stefanoq21/material3/navigation/ModalBottomSheetLayout.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.Dp
 fun ModalBottomSheetLayout(
     bottomSheetNavigator: BottomSheetNavigator,
     modifier: Modifier = Modifier,
+    sheetModifier: Modifier = Modifier,
     sheetMaxWidth: Dp = BottomSheetDefaults.SheetMaxWidth,
     shape: Shape = BottomSheetDefaults.ExpandedShape,
     containerColor: Color = BottomSheetDefaults.ContainerColor,
@@ -63,6 +64,7 @@ fun ModalBottomSheetLayout(
     if (bottomSheetNavigator.sheetEnabled) {
         ModalBottomSheet(
             onDismissRequest = bottomSheetNavigator.onDismissRequest,
+            modifier = sheetModifier,
             sheetState = bottomSheetNavigator.sheetState,
             content = {
                 CompositionLocalProvider(


### PR DESCRIPTION
Hey, this library came in very handy when looking for navigation to M3 bottom sheets!

There is one bit of functionality missing that would make it even better: the ability to pass in a `Modifier` to the actual `ModalBottomSheet` internal to the `ModalBottomSheetLayout`. We use this in other places where we have `ModalBottomSheet`s to be able to set a padding, e.g. so that the sheet doesn't run behind the status bar. Like this:

![image](https://github.com/user-attachments/assets/41739692-8130-408e-b862-5d7f23517053)
