### PR TITLE
Animated navigation between different bottomsheets

### DIFF
--- a/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/MainActivity.kt
+++ b/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/MainActivity.kt
@@ -151,7 +151,16 @@ class MainActivity : ComponentActivity() {
                                         // navController.navigate(Screen.DialogTestScreen)
                                     },
                                     onClickBack = {
-                                        onBackPressedDispatcher.onBackPressed()
+                                        navController.navigateUp()
+                                        // We should not be calling onBackPressed because the event is sent to both navigators at the same time.
+//                                        onBackPressedDispatcher.onBackPressed()
+                                        // You can uncomment this line and do the following to see the issue:
+                                        // 1. Home - go to Zoom.
+                                        // 2. Zoom - go to BottomSheetWithCloseScreen.
+                                        // 3. Click "Close for back".
+
+                                        // Expected: The bottom sheet closes and Zoom page is displayed.
+                                        // Actual: The bottom sheet closes as expected but Zoom is also popped from the backstack.
                                     },
                                     onClickGoToBottomSheet = {
                                         navController.navigate(Screen.BottomSheetWithParameters("testId-123"))
@@ -183,7 +192,9 @@ class MainActivity : ComponentActivity() {
                             bottomSheet<Screen.BottomSheetWithParameters> { backStackEntry ->
                                 val id =
                                     backStackEntry.toRoute<Screen.BottomSheetWithParameters>().id
-                                BSWithParametersLayout(id)
+                                BSWithParametersLayout(id, onPop = navController::popBackStack, openFullscreen = {
+                                    navController.navigate(Screen.BottomSheetFullScreen)
+                                })
                             }
 
 

--- a/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/presentation/screen/bottomSheetWithParameters/BSWithParametersLayout.kt
+++ b/app/src/main/java/com/stefanoq21/bottomsheetnavigator3/presentation/screen/bottomSheetWithParameters/BSWithParametersLayout.kt
@@ -3,6 +3,7 @@ package com.stefanoq21.bottomsheetnavigator3.presentation.screen.bottomSheetWith
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,7 +15,7 @@ import androidx.compose.ui.unit.dp
 
 
 @Composable
-fun BSWithParametersLayout(id: String) {
+fun BSWithParametersLayout(id: String, onPop: () -> Unit, openFullscreen: () -> Unit) {
     Column(Modifier.padding(12.dp)) {
         Text(
             modifier = Modifier.fillMaxWidth(),
@@ -22,6 +23,12 @@ fun BSWithParametersLayout(id: String) {
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
         )
+        Button(onClick = onPop) {
+            Text("Pop")
+        }
+        Button(onClick = openFullscreen) {
+            Text("Fullscreen sheet")
+        }
     }
 }
 


### PR DESCRIPTION
Hi!

I liked how this worked with the exception of navigating from one bottomsheet to another. After some hacking and taking inspiration from [the official library](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt;l=338;drc=00f6c4d7634026174e04e1d8153b4ad8d9cea3fd) I managed to make it all work.

I think everything works as it should. The one thing I had to give up is navigating back with the help of `backPressedDispatcher` as that wasn't processed correctly by the `NavController` (see the comment in `MainActivity`). 

- Back gestures and back button seems to work fine.
- Predictive back support and transitions are also included!
- Re-enable collapse animation with popBackStack.

Let me know what you think. 

